### PR TITLE
.gitignore Changes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/app/static/* linguist-vendored

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ scripts_bank/textfiles/*
 log/*
 instance/settings.py
 flask/
-flask/*
+tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ scripts_bank/textfiles/*
 log/*
 instance/settings.py
 flask/
-tmp/
+tmp/*
+app/log/

--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,13 @@
 # Add any directories, files, or patterns you don't want to be tracked by version control
-*.pyc
+*.csv
 *.log
+*.pyc
+*.txt
 app.db
+app/log/
+flask/
+instance/settings.py
+log/*
 scripts_bank/logs/*
 scripts_bank/textfiles/*
-log/*
-instance/settings.py
-flask/
 tmp/*
-app/log/
-*.txt
-*.csv

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ instance/settings.py
 flask/
 tmp/*
 app/log/
+*.txt
+*.csv

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -1,3 +1,0 @@
-# Add any directories, files, or patterns you don't want to be tracked by version control
-!.gitignore
-*.pyc

--- a/app/log/.gitignore
+++ b/app/log/.gitignore
@@ -1,2 +1,0 @@
-# Add any directories, files, or patterns you don't want to be tracked by version control
-*.log

--- a/app/scripts_bank/.gitignore
+++ b/app/scripts_bank/.gitignore
@@ -1,3 +1,0 @@
-# Add any directories, files, or patterns you don't want to be tracked by version control
-!.gitignore
-*.pyc

--- a/app/scripts_bank/lib/.gitignore
+++ b/app/scripts_bank/lib/.gitignore
@@ -1,3 +1,0 @@
-# Add any directories, files, or patterns you don't want to be tracked by version control
-!.gitignore
-*.pyc

--- a/app/scripts_bank/logs/.gitignore
+++ b/app/scripts_bank/logs/.gitignore
@@ -1,3 +1,0 @@
-# Add any directories, files, or patterns you don't want to be tracked by version control
-*.txt
-*.csv

--- a/app/scripts_bank/textfiles/.gitignore
+++ b/app/scripts_bank/textfiles/.gitignore
@@ -1,3 +1,0 @@
-# Add any directories, files, or patterns you don't want to be tracked by version control
-*.txt
-*.csv

--- a/tmp/.gitignore
+++ b/tmp/.gitignore
@@ -1,1 +1,0 @@
-# Add any directories, files, or patterns you don't want to be tracked by version control


### PR DESCRIPTION
I noticed that there were several .gitignore files, so I've consolidated them into one and combined the actual files/folders to be ignored.

In addition, I've added a .gitattributes file that will tell Github to ignore any third-party Javascript libraries. Github will now properly show this as a Python project rather than a Javascript project.