### PR TITLE
Update rhel7.rst

### DIFF
--- a/docs/installation/rhel7.rst
+++ b/docs/installation/rhel7.rst
@@ -10,7 +10,9 @@ Update RHEL
 Update RHEL, install required system packages, and reboot
 
 .. code-block:: text
-
+    
+    sudo yum update
+    sudo yum install epel-release -y
     sudo yum upgrade
     sudo yum -y install gcc python python-devel python-pip nginx redis supervisor python-gunicorn git
     sudo reboot now
@@ -26,6 +28,7 @@ Set any password you choose.
 
     sudo adduser netconfig
     sudo passwd netconfig
+    sudo usermod -a -G wheel netconfig
 
 Switch to the new Netconfig user
 
@@ -100,7 +103,16 @@ Create symlink for netconfig file into nginx/sites-enabled
 
     sudo ln -s /etc/nginx/sites-available/netconfig /etc/nginx/sites-enabled
 
+Firewall Rules
+^^^^^^^^^^^^^^
 
+Create firewall rules for allowing access
+
+.. code-block:: text
+
+    sudo firewall-cmd --permanent --add-port 443/tcp
+    sudo firewall-cmd --reload
+    
 Service
 ^^^^^^^
 


### PR DESCRIPTION
Adding additional steps required on netconfig installations on CentOS/RHEL 7:
 - yum update and epel-release installation so you can install python-pip and other packages
 - adding netconfig user to group wheel, as you *can't use sudo if you're not a member of the wheel group*. This assumes a default installation and that's required on a default installation. 
 - firewall rules so we can access the vm on :443

The rest seemed to work.